### PR TITLE
feat: add NJ gubernatorial placeholder

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -433,6 +433,20 @@
         .dropdown-option.selected::before {
             display: none;
         }
+
+        .dropdown-option.coming-soon {
+            color: var(--text-muted);
+            cursor: not-allowed;
+        }
+
+        .dropdown-option.coming-soon:hover {
+            background: none;
+            padding-left: 20px;
+        }
+
+        .dropdown-option.coming-soon::before {
+            display: none;
+        }
         
         .card { 
             background: var(--card-bg); 

--- a/js/script.js
+++ b/js/script.js
@@ -5061,7 +5061,14 @@
                     dropdownOptions.appendChild(option);
                 });
             });
-    
+
+            // Add coming soon placeholder for NJ Gubernatorial Forecast
+            const njOption = document.createElement('div');
+            njOption.className = 'dropdown-option coming-soon';
+            njOption.innerHTML = `<i class="fas fa-chart-line option-icon"></i><span>NJ Gubernatorial Forecast</span>`;
+            njOption.setAttribute('data-tooltip', 'Coming Soon');
+            dropdownOptions.appendChild(njOption);
+
             dropdownSelected.addEventListener('click', () => {
                 dropdownSelected.classList.toggle('active');
                 dropdownOptions.classList.toggle('active');


### PR DESCRIPTION
## Summary
- add disabled NJ Gubernatorial Forecast placeholder to main dropdown with "Coming Soon" tooltip
- style dropdown placeholder as grey and non-interactive

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68981f1bf9388322aab8035b528a25b5