### PR TITLE
Fix highlight zoom when all pollsters selected

### DIFF
--- a/js/script.js
+++ b/js/script.js
@@ -3908,6 +3908,7 @@
             idleCallback(() => {
                 applyFilters();
                 if (selectedPollster === 'all' && searchQuery.trim() === '' &&
+                    !currentZoomSelection.isActive &&
                     currentAggregate.precomputed && currentAggregate.precomputed[currentTerm]) {
                     aggregatedData = cloneAggregatedData(currentAggregate.precomputed[currentTerm]);
                     isProcessing = false;


### PR DESCRIPTION
## Summary
- prevent precomputed poll data from overriding active highlight-zoom ranges
- allow highlight zoom to function with 'All Pollsters' selection by recomputing aggregation when zooming

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689951c562e4832291fc9218e1933019