### PR TITLE
Add 2028 Newsom–Vance polling aggregate and chart

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -42,8 +42,12 @@
             --unfavorable-color-glow: rgba(249, 115, 22, 0.4);
             --trump-color: #ef4444;
             --harris-color: #3b82f6;
+            --vance-color: #dc2626;
+            --newsom-color: #2563eb;
             --trump-color-glow: rgba(239, 68, 68, 0.4);
             --harris-color-glow: rgba(59, 130, 246, 0.4);
+            --vance-color-glow: rgba(220, 38, 38, 0.4);
+            --newsom-color-glow: rgba(37, 99, 235, 0.4);
             --highlight-zoom-border: #8b5cf6;
             --highlight-zoom-bg: rgba(139, 92, 246, 0.15);
             --glass-bg: rgba(255, 255, 255, 0.02);
@@ -81,8 +85,12 @@
             --unfavorable-color-glow: rgba(249, 115, 22, 0.4);
             --trump-color: #ef4444;
             --harris-color: #3b82f6;
+            --vance-color: #dc2626;
+            --newsom-color: #2563eb;
             --trump-color-glow: rgba(239, 68, 68, 0.4);
             --harris-color-glow: rgba(59, 130, 246, 0.4);
+            --vance-color-glow: rgba(220, 38, 38, 0.4);
+            --newsom-color-glow: rgba(37, 99, 235, 0.4);
             --highlight-zoom-border: #8b5cf6;
             --highlight-zoom-bg: rgba(139, 92, 246, 0.15);
             --glass-bg: rgba(255, 255, 255, 0.05);
@@ -121,8 +129,12 @@
             --unfavorable-color-glow: rgba(245, 158, 11, 0.3);
             --trump-color: #dc2626;
             --harris-color: #2563eb;
+            --vance-color: #b91c1c;
+            --newsom-color: #1e3a8a;
             --trump-color-glow: rgba(220, 38, 38, 0.3);
             --harris-color-glow: rgba(37, 99, 235, 0.3);
+            --vance-color-glow: rgba(185, 28, 28, 0.3);
+            --newsom-color-glow: rgba(30, 58, 138, 0.3);
             --highlight-zoom-border: #7c3aed;
             --highlight-zoom-bg: rgba(124, 58, 237, 0.1);
             --glass-bg: rgba(0, 0, 0, 0.01);
@@ -310,6 +322,8 @@
         .animate-word.republican { color: var(--trump-color); }
         .animate-word.harris { color: var(--harris-color); }
         .animate-word.democrat { color: var(--harris-color); }
+        .animate-word.vance { color: var(--vance-color); }
+        .animate-word.newsom { color: var(--newsom-color); }
 
         .selectors-wrapper { 
             display: flex; 
@@ -2150,6 +2164,8 @@
         .poll-percentage.harris { color: var(--harris-color); }
         .poll-percentage.republican { color: var(--trump-color); }
         .poll-percentage.democrat { color: var(--harris-color); }
+        .poll-percentage.vance { color: var(--vance-color); }
+        .poll-percentage.newsom { color: var(--newsom-color); }
         
         .poll-date { 
             color: var(--text-secondary);
@@ -2414,6 +2430,8 @@
         .unfavorable-line { filter: drop-shadow(0 0 4px var(--unfavorable-color-glow)); }
         .trump-line { filter: drop-shadow(0 0 4px var(--trump-color-glow)); }
         .harris-line { filter: drop-shadow(0 0 4px var(--harris-color-glow)); }
+        .vance-line { filter: drop-shadow(0 0 4px var(--vance-color-glow)); }
+        .newsom-line { filter: drop-shadow(0 0 4px var(--newsom-color-glow)); }
         
         .mini-aggregate-display::after { 
             content: ''; 

--- a/js/script.js
+++ b/js/script.js
@@ -2903,7 +2903,19 @@
 
   /* ========== Fabrizio &&nbsp;Anzalone (RV) ========== */
   { pollster: "Fabrizio & Anzalone", date: "2025-02-01", sampleSize: 3000, approve: 43, disapprove: 43, quality: "A+" }
-                ] 
+                ]
+            },
+            {
+                id: 'race2028', name: '2028 Presidential Race', baseId: 'race2028', category: '2028 Election', isRace: true,
+                candidates: ['Vance', 'Newsom'], pollFields: ['approve', 'disapprove'],
+                colors: ['var(--vance-color)', 'var(--newsom-color)'], directColors: ['#dc2626', '#2563eb'],
+                colorGlow: ['var(--vance-color-glow)', 'var(--newsom-color-glow)'], directGlowColors: ['rgba(220,38,38,0.4)', 'rgba(37,99,235,0.4)'],
+                lineClasses: ['vance-line', 'newsom-line'],
+                polls: [
+  { pollster: "Emerson College Polling", date: "2025-07-22", sampleSize: 1400, approve: 45, disapprove: 42, moe: 2.5, starRating: 2.9, houseEffect: -0.8, quality: "B" },
+  { pollster: "Emerson College Polling", date: "2025-08-26", sampleSize: 1000, approve: 44, disapprove: 44, moe: 3.0, starRating: 2.9, houseEffect: -0.8, quality: "B" },
+  { pollster: "SoCal Strategies", date: "2025-08-19", sampleSize: 700, approve: 37, disapprove: 39, moe: 3.5, starRating: 1.0, houseEffect: 2.0, quality: "D" }
+                ]
             }
         ];
         
@@ -3213,7 +3225,7 @@
         let currentLineDetail = 3; // 1-5 scale for line detail/sampling
         let animationFrameId = null;
         let wordCyclerInterval = null;
-        let aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+        let aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
         let pollPointGrid = {}; 
         let hoverDisplayState = { active: false, xChart: 0, date: null, points: [], spreadsInfo: [] };
         let chartDimensions = { margin: { top: 50, right: 30, bottom: 40, left: 30 }, width: 0, height: 0, yMin: DEFAULT_Y_MIN, yMax: DEFAULT_Y_MAX };
@@ -3335,6 +3347,9 @@
         // --- Sampling & Rendering Helpers ---
         
         function computeBasePollWeight(poll) {
+            if (poll.starRating !== undefined) {
+                return Math.sqrt(poll.sampleSize || 0) * (poll.starRating / 3.0);
+            }
             const qualityWeight = POLL_QUALITY_WEIGHTS[poll.quality] || 0.5;
             const sampleWeight = Math.sqrt(poll.sampleSize || 100) / 100;
             return qualityWeight * sampleWeight;
@@ -3344,6 +3359,13 @@
             const processPollArray = arr => arr.map(p => {
                 if(!(p.date instanceof Date)){
                     p.date = new Date(p.date + 'T12:00:00Z');
+                }
+                if(p.houseEffect !== undefined){
+                    p.approve = Math.max(0, Math.min(100, p.approve - p.houseEffect));
+                    p.disapprove = Math.max(0, Math.min(100, p.disapprove + p.houseEffect));
+                }
+                if(p.starRating !== undefined && p.decay === undefined){
+                    p.decay = 90;
                 }
                 if(p.baseWeight === undefined){
                     p.baseWeight = computeBasePollWeight(p);
@@ -3365,7 +3387,8 @@
             const pollDate = poll.date.getTime();
             const daysDiff = (referenceDate.getTime() - pollDate) / MS_PER_DAY;
             if (daysDiff < 0) return 0;
-            const recencyWeight = Math.exp(-daysDiff / HALF_LIFE);
+            const decay = poll.decay || (poll.starRating !== undefined ? 90 : HALF_LIFE);
+            const recencyWeight = Math.exp(-daysDiff / decay);
             const baseWeight = poll.baseWeight ?? computeBasePollWeight(poll);
             return baseWeight * recencyWeight;
         }
@@ -4057,9 +4080,22 @@
 
             let approveClass, disapproveClass;
             switch(currentAggregate.baseId || currentAggregate.id){
-                case 'generic_ballot': approveClass = 'poll-percentage republican'; disapproveClass = 'poll-percentage democrat'; break;
-                case 'race2024': approveClass = 'poll-percentage trump'; disapproveClass = 'poll-percentage harris'; break;
-                default: approveClass = 'poll-percentage approve'; disapproveClass = 'poll-percentage disapprove';
+                case 'generic_ballot':
+                    approveClass = 'poll-percentage republican';
+                    disapproveClass = 'poll-percentage democrat';
+                    break;
+                case 'race2024':
+                    approveClass = 'poll-percentage trump';
+                    disapproveClass = 'poll-percentage harris';
+                    break;
+                case 'race2028':
+                    approveClass = 'poll-percentage vance';
+                    disapproveClass = 'poll-percentage newsom';
+                    break;
+                default:
+                    approveClass = 'poll-percentage approve';
+                    disapproveClass = 'poll-percentage disapprove';
+                    break;
             }
             
             tableRow.innerHTML = `<td><div class="pollster-name"><div class="pollster-logo">${initials}</div>${displayPollster}</div></td><td class="poll-date">${displayDate}</td><td class="poll-info">${displaySampleSize}</td><td><div class="poll-quality">${formatQualityStars(poll.quality)}</div></td><td class="${approveClass}">${displayApprove}</td><td class="${disapproveClass}">${displayDisapprove}</td>${marginHtml}<td class="poll-info">${weight.toFixed(3)}</td>`;
@@ -4067,7 +4103,7 @@
         }
 
         function calculateSeriesValues(sortedPolls, timestamps, field1, field2) {
-            const values1 = [], values2 = [];
+            const values1 = [], values2 = [], moes = [];
             let pollIdx = 0;
             let active = [];
 
@@ -4080,7 +4116,9 @@
                         date: p.date,
                         baseWeight: p.baseWeight ?? computeBasePollWeight(p),
                         val1: p[field1],
-                        val2: p[field2]
+                        val2: p[field2],
+                        moe: p.moe || 0,
+                        decay: p.decay || (p.starRating !== undefined ? 90 : HALF_LIFE)
                     });
                     pollIdx++;
                 }
@@ -4088,29 +4126,38 @@
                 if (active.length === 0) {
                     values1[i] = null;
                     values2[i] = null;
+                    moes[i] = null;
                     continue;
                 }
 
-                let weightedSum1 = 0, weightedSum2 = 0, totalWeight = 0;
+                let weightedSum1 = 0, weightedSum2 = 0, weightedMoe = 0, totalWeight = 0;
                 const newActive = [];
                 for (let k = 0; k < active.length; k++) {
                     const ap = active[k];
                     const daysDiff = (currentDate.getTime() - ap.date.getTime()) / MS_PER_DAY;
-                    const weight = ap.baseWeight * Math.exp(-daysDiff / HALF_LIFE);
+                    const weight = ap.baseWeight * Math.exp(-daysDiff / ap.decay);
                     if (weight > 0.001) {
                         weightedSum1 += ap.val1 * weight;
                         weightedSum2 += ap.val2 * weight;
+                        weightedMoe += ap.moe * weight;
                         totalWeight += weight;
                         newActive.push(ap);
                     }
                 }
                 active = newActive;
 
-                values1[i] = totalWeight > 0 ? weightedSum1 / totalWeight : null;
-                values2[i] = totalWeight > 0 ? weightedSum2 / totalWeight : null;
+                if (totalWeight > 0) {
+                    values1[i] = weightedSum1 / totalWeight;
+                    values2[i] = weightedSum2 / totalWeight;
+                    moes[i] = weightedMoe / totalWeight;
+                } else {
+                    values1[i] = null;
+                    values2[i] = null;
+                    moes[i] = null;
+                }
             }
 
-            return [values1, values2];
+            return [values1, values2, moes];
         }
         
         function updateAggregation() {
@@ -4123,7 +4170,7 @@
             pollCountBadge.textContent = `${countForBadge} poll${countForBadge !== 1 ? 's' : ''}`;
 
             function setEmptyAggData() {
-                aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+                aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
                 updateDisplay();
                 isProcessing = false;
             }
@@ -4161,7 +4208,7 @@
             latestPollDateOverall = new Date(Math.min(latestPollDateOverall.getTime(), referenceDate.getTime()));
 
             if (earliestPollDateOverall.getTime() > latestPollDateOverall.getTime()) { 
-                aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+                aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
                 updateDisplay();
                 isProcessing = false;
                 return;
@@ -4176,7 +4223,7 @@
             }
             
             if (startDateForAggregation.getTime() > endDateForAggregation.getTime()) { 
-                aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+                aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
                 updateDisplay();
                 isProcessing = false;
                 return; 
@@ -4204,7 +4251,7 @@
             }
             
             if (timestamps.length === 0) { 
-                aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+                aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
                 updateDisplay();
                 isProcessing = false;
                 return;
@@ -4215,11 +4262,13 @@
             const field2 = currentAggregate.pollFields[1];
             aggregatedData.values = [[], []];
 
-            const [vals1, vals2] = calculateSeriesValues(sortedPolls, timestamps, field1, field2);
+            const [vals1, vals2, moes] = calculateSeriesValues(sortedPolls, timestamps, field1, field2);
             aggregatedData.values[0] = vals1;
             aggregatedData.values[1] = vals2;
+            aggregatedData.moes = moes;
 
             aggregatedData.current = [ aggregatedData.values[0].at(-1), aggregatedData.values[1].at(-1) ];
+            aggregatedData.currentMoe = aggregatedData.moes.at(-1);
             aggregatedData.spreads = aggregatedData.timestamps.map((_, i) => 
                 (aggregatedData.values[0][i] === null || aggregatedData.values[1][i] === null) 
                     ? null 
@@ -4292,7 +4341,7 @@
             let result;
             currentAggregate = aggConfig;
             currentTerm = term;
-            aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+            aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
             updateDisplay = () => {};
             try {
                 computeAggregationData([...polls]);
@@ -4315,7 +4364,7 @@
                     if (polls && polls.length > 0) {
                         agg.precomputed[term] = computeAggregatedSnapshot(polls, agg, term);
                     } else {
-                        agg.precomputed[term] = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+                        agg.precomputed[term] = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
                     }
                 });
             });
@@ -4340,9 +4389,22 @@
             
             let animClass1, animClass2;
             switch(currentAggregate.baseId || currentAggregate.id) {
-                case 'race2024': animClass1 = 'trump'; animClass2 = 'harris'; break;
-                case 'generic_ballot': animClass1 = 'republican'; animClass2 = 'democrat'; break;
-                default: animClass1 = 'approve'; animClass2 = 'disapprove'; break;
+                case 'race2024':
+                    animClass1 = 'trump';
+                    animClass2 = 'harris';
+                    break;
+                case 'race2028':
+                    animClass1 = 'vance';
+                    animClass2 = 'newsom';
+                    break;
+                case 'generic_ballot':
+                    animClass1 = 'republican';
+                    animClass2 = 'democrat';
+                    break;
+                default:
+                    animClass1 = 'approve';
+                    animClass2 = 'disapprove';
+                    break;
             }
             const animClasses = [animClass1, animClass2];
             
@@ -4558,6 +4620,32 @@
             const drawFullChart = (progress = 1) => {
                 clear(ctx);
                 generateGrid();
+
+                if (aggregatedData.moes && aggregatedData.moes.length > 0) {
+                    for (let lineIdx = 0; lineIdx < 2; lineIdx++) {
+                        const upper = [], lower = [];
+                        aggregatedData.timestamps.forEach((date, i) => {
+                            const val = aggregatedData.values[lineIdx][i];
+                            const moe = aggregatedData.moes[i];
+                            if (val !== null && moe !== null) {
+                                const x = xScale(date);
+                                upper.push([x, yScale(val + moe)]);
+                                lower.unshift([x, yScale(val - moe)]);
+                            }
+                        });
+                        if (upper.length > 0) {
+                            const path = new Path2D();
+                            path.moveTo(upper[0][0], upper[0][1]);
+                            for (let j = 1; j < upper.length; j++) path.lineTo(upper[j][0], upper[j][1]);
+                            for (let j = 0; j < lower.length; j++) path.lineTo(lower[j][0], lower[j][1]);
+                            path.closePath();
+                            ctx.save();
+                            ctx.fillStyle = convertToRgba(getComputedColor(currentAggregate.colors[lineIdx]), 0.15);
+                            ctx.fill(path);
+                            ctx.restore();
+                        }
+                    }
+                }
 
                 linePaths.forEach((lineData, lineIdx) => {
                     if (!lineData) return;


### PR DESCRIPTION
## Summary
- integrate 2028 Newsom vs. Vance polls into main aggregate list with new color scheme
- account for pollster house effects and star-rating weights when computing averages and MOE
- render confidence bands around Vance and Newsom trend lines

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bd3f6a9483229ff8ae4f71ed9205