### PR TITLE
Add 2028 Newsom–Vance polling aggregate and chart

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -42,8 +42,12 @@
             --unfavorable-color-glow: rgba(249, 115, 22, 0.4);
             --trump-color: #ef4444;
             --harris-color: #3b82f6;
+            --vance-color: #dc2626;
+            --newsom-color: #2563eb;
             --trump-color-glow: rgba(239, 68, 68, 0.4);
             --harris-color-glow: rgba(59, 130, 246, 0.4);
+            --vance-color-glow: rgba(220, 38, 38, 0.4);
+            --newsom-color-glow: rgba(37, 99, 235, 0.4);
             --highlight-zoom-border: #8b5cf6;
             --highlight-zoom-bg: rgba(139, 92, 246, 0.15);
             --glass-bg: rgba(255, 255, 255, 0.02);
@@ -81,8 +85,12 @@
             --unfavorable-color-glow: rgba(249, 115, 22, 0.4);
             --trump-color: #ef4444;
             --harris-color: #3b82f6;
+            --vance-color: #dc2626;
+            --newsom-color: #2563eb;
             --trump-color-glow: rgba(239, 68, 68, 0.4);
             --harris-color-glow: rgba(59, 130, 246, 0.4);
+            --vance-color-glow: rgba(220, 38, 38, 0.4);
+            --newsom-color-glow: rgba(37, 99, 235, 0.4);
             --highlight-zoom-border: #8b5cf6;
             --highlight-zoom-bg: rgba(139, 92, 246, 0.15);
             --glass-bg: rgba(255, 255, 255, 0.05);
@@ -121,8 +129,12 @@
             --unfavorable-color-glow: rgba(245, 158, 11, 0.3);
             --trump-color: #dc2626;
             --harris-color: #2563eb;
+            --vance-color: #b91c1c;
+            --newsom-color: #1e3a8a;
             --trump-color-glow: rgba(220, 38, 38, 0.3);
             --harris-color-glow: rgba(37, 99, 235, 0.3);
+            --vance-color-glow: rgba(185, 28, 28, 0.3);
+            --newsom-color-glow: rgba(30, 58, 138, 0.3);
             --highlight-zoom-border: #7c3aed;
             --highlight-zoom-bg: rgba(124, 58, 237, 0.1);
             --glass-bg: rgba(0, 0, 0, 0.01);
@@ -301,6 +313,12 @@
             opacity: 1;
             transform: translateY(0);
         }
+
+        /* Inline variant for titles that show multiple words simultaneously */
+        .animate-word.inline {
+            position: static;
+            width: auto;
+        }
         
         .animate-word.approve { color: var(--approve-color); }
         .animate-word.disapprove { color: var(--disapprove-color); }
@@ -310,6 +328,8 @@
         .animate-word.republican { color: var(--trump-color); }
         .animate-word.harris { color: var(--harris-color); }
         .animate-word.democrat { color: var(--harris-color); }
+        .animate-word.vance { color: var(--vance-color); }
+        .animate-word.newsom { color: var(--newsom-color); }
 
         .selectors-wrapper { 
             display: flex; 
@@ -2150,6 +2170,8 @@
         .poll-percentage.harris { color: var(--harris-color); }
         .poll-percentage.republican { color: var(--trump-color); }
         .poll-percentage.democrat { color: var(--harris-color); }
+        .poll-percentage.vance { color: var(--vance-color); }
+        .poll-percentage.newsom { color: var(--newsom-color); }
         
         .poll-date { 
             color: var(--text-secondary);
@@ -2414,6 +2436,8 @@
         .unfavorable-line { filter: drop-shadow(0 0 4px var(--unfavorable-color-glow)); }
         .trump-line { filter: drop-shadow(0 0 4px var(--trump-color-glow)); }
         .harris-line { filter: drop-shadow(0 0 4px var(--harris-color-glow)); }
+        .vance-line { filter: drop-shadow(0 0 4px var(--vance-color-glow)); }
+        .newsom-line { filter: drop-shadow(0 0 4px var(--newsom-color-glow)); }
         
         .mini-aggregate-display::after { 
             content: ''; 

--- a/js/script.js
+++ b/js/script.js
@@ -2903,7 +2903,20 @@
 
   /* ========== Fabrizio &&nbsp;Anzalone (RV) ========== */
   { pollster: "Fabrizio & Anzalone", date: "2025-02-01", sampleSize: 3000, approve: 43, disapprove: 43, quality: "A+" }
-                ] 
+                ]
+            },
+            {
+                id: 'race2028', name: '2028 Presidential Race', baseId: 'race2028', category: '2028 Election', isRace: true,
+                candidates: ['Vance', 'Newsom'], pollFields: ['approve', 'disapprove'],
+                colors: ['var(--vance-color)', 'var(--newsom-color)'], directColors: ['#dc2626', '#2563eb'],
+                colorGlow: ['var(--vance-color-glow)', 'var(--newsom-color-glow)'], directGlowColors: ['rgba(220,38,38,0.4)', 'rgba(37,99,235,0.4)'],
+                lineClasses: ['vance-line', 'newsom-line'],
+                polls: [
+  { pollster: "Overton Insights", date: "2025-06-26", sampleSize: 1200, approve: 46, disapprove: 43, moe: 2.8, decay: 90, baseWeight: 34.641, quality: "B" },
+  { pollster: "Emerson College Polling", date: "2025-07-22", sampleSize: 1400, approve: 45, disapprove: 42, moe: 2.5, decay: 90, baseWeight: 37.417, quality: "B" },
+  { pollster: "OnPoint/SoCal Strategies", date: "2025-08-18", sampleSize: 700, approve: 37, disapprove: 39, moe: 3.7, decay: 90, baseWeight: 6.614, quality: "D" },
+  { pollster: "Emerson College Polling", date: "2025-08-26", sampleSize: 1000, approve: 44, disapprove: 44, moe: 3.0, decay: 90, baseWeight: 31.623, quality: "B" }
+                ]
             }
         ];
         
@@ -3213,7 +3226,7 @@
         let currentLineDetail = 3; // 1-5 scale for line detail/sampling
         let animationFrameId = null;
         let wordCyclerInterval = null;
-        let aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+        let aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
         let pollPointGrid = {}; 
         let hoverDisplayState = { active: false, xChart: 0, date: null, points: [], spreadsInfo: [] };
         let chartDimensions = { margin: { top: 50, right: 30, bottom: 40, left: 30 }, width: 0, height: 0, yMin: DEFAULT_Y_MIN, yMax: DEFAULT_Y_MAX };
@@ -3335,6 +3348,9 @@
         // --- Sampling & Rendering Helpers ---
         
         function computeBasePollWeight(poll) {
+            if (poll.starRating !== undefined) {
+                return Math.sqrt(poll.sampleSize || 0) * (poll.starRating / 3.0);
+            }
             const qualityWeight = POLL_QUALITY_WEIGHTS[poll.quality] || 0.5;
             const sampleWeight = Math.sqrt(poll.sampleSize || 100) / 100;
             return qualityWeight * sampleWeight;
@@ -3344,6 +3360,13 @@
             const processPollArray = arr => arr.map(p => {
                 if(!(p.date instanceof Date)){
                     p.date = new Date(p.date + 'T12:00:00Z');
+                }
+                if(p.houseEffect !== undefined){
+                    p.approve = Math.max(0, Math.min(100, p.approve - p.houseEffect));
+                    p.disapprove = Math.max(0, Math.min(100, p.disapprove + p.houseEffect));
+                }
+                if(p.starRating !== undefined && p.decay === undefined){
+                    p.decay = 90;
                 }
                 if(p.baseWeight === undefined){
                     p.baseWeight = computeBasePollWeight(p);
@@ -3365,7 +3388,8 @@
             const pollDate = poll.date.getTime();
             const daysDiff = (referenceDate.getTime() - pollDate) / MS_PER_DAY;
             if (daysDiff < 0) return 0;
-            const recencyWeight = Math.exp(-daysDiff / HALF_LIFE);
+            const decay = poll.decay || (poll.starRating !== undefined ? 90 : HALF_LIFE);
+            const recencyWeight = Math.exp(-daysDiff / decay);
             const baseWeight = poll.baseWeight ?? computeBasePollWeight(poll);
             return baseWeight * recencyWeight;
         }
@@ -4057,9 +4081,22 @@
 
             let approveClass, disapproveClass;
             switch(currentAggregate.baseId || currentAggregate.id){
-                case 'generic_ballot': approveClass = 'poll-percentage republican'; disapproveClass = 'poll-percentage democrat'; break;
-                case 'race2024': approveClass = 'poll-percentage trump'; disapproveClass = 'poll-percentage harris'; break;
-                default: approveClass = 'poll-percentage approve'; disapproveClass = 'poll-percentage disapprove';
+                case 'generic_ballot':
+                    approveClass = 'poll-percentage republican';
+                    disapproveClass = 'poll-percentage democrat';
+                    break;
+                case 'race2024':
+                    approveClass = 'poll-percentage trump';
+                    disapproveClass = 'poll-percentage harris';
+                    break;
+                case 'race2028':
+                    approveClass = 'poll-percentage vance';
+                    disapproveClass = 'poll-percentage newsom';
+                    break;
+                default:
+                    approveClass = 'poll-percentage approve';
+                    disapproveClass = 'poll-percentage disapprove';
+                    break;
             }
             
             tableRow.innerHTML = `<td><div class="pollster-name"><div class="pollster-logo">${initials}</div>${displayPollster}</div></td><td class="poll-date">${displayDate}</td><td class="poll-info">${displaySampleSize}</td><td><div class="poll-quality">${formatQualityStars(poll.quality)}</div></td><td class="${approveClass}">${displayApprove}</td><td class="${disapproveClass}">${displayDisapprove}</td>${marginHtml}<td class="poll-info">${weight.toFixed(3)}</td>`;
@@ -4067,7 +4104,7 @@
         }
 
         function calculateSeriesValues(sortedPolls, timestamps, field1, field2) {
-            const values1 = [], values2 = [];
+            const values1 = [], values2 = [], moes = [];
             let pollIdx = 0;
             let active = [];
 
@@ -4080,7 +4117,9 @@
                         date: p.date,
                         baseWeight: p.baseWeight ?? computeBasePollWeight(p),
                         val1: p[field1],
-                        val2: p[field2]
+                        val2: p[field2],
+                        moe: p.moe || 0,
+                        decay: p.decay || (p.starRating !== undefined ? 90 : HALF_LIFE)
                     });
                     pollIdx++;
                 }
@@ -4088,29 +4127,38 @@
                 if (active.length === 0) {
                     values1[i] = null;
                     values2[i] = null;
+                    moes[i] = null;
                     continue;
                 }
 
-                let weightedSum1 = 0, weightedSum2 = 0, totalWeight = 0;
+                let weightedSum1 = 0, weightedSum2 = 0, weightedMoe = 0, totalWeight = 0;
                 const newActive = [];
                 for (let k = 0; k < active.length; k++) {
                     const ap = active[k];
                     const daysDiff = (currentDate.getTime() - ap.date.getTime()) / MS_PER_DAY;
-                    const weight = ap.baseWeight * Math.exp(-daysDiff / HALF_LIFE);
+                    const weight = ap.baseWeight * Math.exp(-daysDiff / ap.decay);
                     if (weight > 0.001) {
                         weightedSum1 += ap.val1 * weight;
                         weightedSum2 += ap.val2 * weight;
+                        weightedMoe += ap.moe * weight;
                         totalWeight += weight;
                         newActive.push(ap);
                     }
                 }
                 active = newActive;
 
-                values1[i] = totalWeight > 0 ? weightedSum1 / totalWeight : null;
-                values2[i] = totalWeight > 0 ? weightedSum2 / totalWeight : null;
+                if (totalWeight > 0) {
+                    values1[i] = weightedSum1 / totalWeight;
+                    values2[i] = weightedSum2 / totalWeight;
+                    moes[i] = weightedMoe / totalWeight;
+                } else {
+                    values1[i] = null;
+                    values2[i] = null;
+                    moes[i] = null;
+                }
             }
 
-            return [values1, values2];
+            return [values1, values2, moes];
         }
         
         function updateAggregation() {
@@ -4123,7 +4171,7 @@
             pollCountBadge.textContent = `${countForBadge} poll${countForBadge !== 1 ? 's' : ''}`;
 
             function setEmptyAggData() {
-                aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+                aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
                 updateDisplay();
                 isProcessing = false;
             }
@@ -4161,7 +4209,7 @@
             latestPollDateOverall = new Date(Math.min(latestPollDateOverall.getTime(), referenceDate.getTime()));
 
             if (earliestPollDateOverall.getTime() > latestPollDateOverall.getTime()) { 
-                aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+                aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
                 updateDisplay();
                 isProcessing = false;
                 return;
@@ -4176,7 +4224,7 @@
             }
             
             if (startDateForAggregation.getTime() > endDateForAggregation.getTime()) { 
-                aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+                aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
                 updateDisplay();
                 isProcessing = false;
                 return; 
@@ -4204,7 +4252,7 @@
             }
             
             if (timestamps.length === 0) { 
-                aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+                aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
                 updateDisplay();
                 isProcessing = false;
                 return;
@@ -4215,11 +4263,13 @@
             const field2 = currentAggregate.pollFields[1];
             aggregatedData.values = [[], []];
 
-            const [vals1, vals2] = calculateSeriesValues(sortedPolls, timestamps, field1, field2);
+            const [vals1, vals2, moes] = calculateSeriesValues(sortedPolls, timestamps, field1, field2);
             aggregatedData.values[0] = vals1;
             aggregatedData.values[1] = vals2;
+            aggregatedData.moes = moes;
 
             aggregatedData.current = [ aggregatedData.values[0].at(-1), aggregatedData.values[1].at(-1) ];
+            aggregatedData.currentMoe = aggregatedData.moes.at(-1);
             aggregatedData.spreads = aggregatedData.timestamps.map((_, i) => 
                 (aggregatedData.values[0][i] === null || aggregatedData.values[1][i] === null) 
                     ? null 
@@ -4292,7 +4342,7 @@
             let result;
             currentAggregate = aggConfig;
             currentTerm = term;
-            aggregatedData = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+            aggregatedData = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
             updateDisplay = () => {};
             try {
                 computeAggregationData([...polls]);
@@ -4315,7 +4365,7 @@
                     if (polls && polls.length > 0) {
                         agg.precomputed[term] = computeAggregatedSnapshot(polls, agg, term);
                     } else {
-                        agg.precomputed[term] = { timestamps: [], values: [[], []], spreads: [], current: [null, null], pollPoints: [] };
+                        agg.precomputed[term] = { timestamps: [], values: [[], []], spreads: [], moes: [], current: [null, null], currentMoe: null, pollPoints: [] };
                     }
                 });
             });
@@ -4340,15 +4390,34 @@
             
             let animClass1, animClass2;
             switch(currentAggregate.baseId || currentAggregate.id) {
-                case 'race2024': animClass1 = 'trump'; animClass2 = 'harris'; break;
-                case 'generic_ballot': animClass1 = 'republican'; animClass2 = 'democrat'; break;
-                default: animClass1 = 'approve'; animClass2 = 'disapprove'; break;
+                case 'race2024':
+                    animClass1 = 'trump';
+                    animClass2 = 'harris';
+                    break;
+                case 'race2028':
+                    animClass1 = 'vance';
+                    animClass2 = 'newsom';
+                    break;
+                case 'generic_ballot':
+                    animClass1 = 'republican';
+                    animClass2 = 'democrat';
+                    break;
+                default:
+                    animClass1 = 'approve';
+                    animClass2 = 'disapprove';
+                    break;
             }
             const animClasses = [animClass1, animClass2];
             
+            let customRaceTitle = false;
             if (isRace) {
-                titlePrefix += `: ${candidates[0]} vs`;
-                cyclingWordsData = [{ word: candidates[1], class: animClasses[1], animationType: 'fade-in' }];
+                if ((currentAggregate.baseId || currentAggregate.id) === 'race2028') {
+                    customRaceTitle = true;
+                    titlePrefix += ':';
+                } else {
+                    titlePrefix += `: ${candidates[0]} vs`;
+                    cyclingWordsData = [{ word: candidates[1], class: animClasses[1], animationType: 'fade-in' }];
+                }
             } else {
                 titlePrefix += `:`;
                 cyclingWordsData = [
@@ -4358,27 +4427,50 @@
             }
 
             titleTextEl.textContent = titlePrefix;
-            
-            wordCyclerEl.innerHTML = '';
-            cyclingWordsData.forEach(data => {
-                const span = document.createElement('span');
-                span.className = `animate-word ${data.class} ${data.animationType}`;
-                span.textContent = data.word;
-                wordCyclerEl.appendChild(span);
-            });
 
-            const words = wordCyclerEl.querySelectorAll('.animate-word');
-            if (words.length > 1) {
-                let currentIndex = 0;
-                words[currentIndex].classList.add('visible');
-                
-                wordCyclerInterval = setInterval(() => {
-                    words[currentIndex].classList.remove('visible');
-                    currentIndex = (currentIndex + 1) % words.length;
+            wordCyclerEl.innerHTML = '';
+            if (customRaceTitle) {
+                const c1 = document.createElement('span');
+                c1.className = `animate-word inline ${animClasses[0]} pop-in`;
+                c1.textContent = candidates[0];
+
+                const vs = document.createElement('span');
+                vs.textContent = ' vs ';
+
+                const c2 = document.createElement('span');
+                c2.className = `animate-word inline ${animClasses[1]} pop-in`;
+                c2.textContent = candidates[1];
+                c2.style.transitionDelay = '0.2s';
+
+                wordCyclerEl.appendChild(c1);
+                wordCyclerEl.appendChild(vs);
+                wordCyclerEl.appendChild(c2);
+
+                requestAnimationFrame(() => {
+                    c1.classList.add('visible');
+                    c2.classList.add('visible');
+                });
+            } else {
+                cyclingWordsData.forEach(data => {
+                    const span = document.createElement('span');
+                    span.className = `animate-word ${data.class} ${data.animationType}`;
+                    span.textContent = data.word;
+                    wordCyclerEl.appendChild(span);
+                });
+
+                const words = wordCyclerEl.querySelectorAll('.animate-word');
+                if (words.length > 1) {
+                    let currentIndex = 0;
                     words[currentIndex].classList.add('visible');
-                }, 3000);
-            } else if (words.length === 1) {
-                 words[0].classList.add('visible');
+
+                    wordCyclerInterval = setInterval(() => {
+                        words[currentIndex].classList.remove('visible');
+                        currentIndex = (currentIndex + 1) % words.length;
+                        words[currentIndex].classList.add('visible');
+                    }, 3000);
+                } else if (words.length === 1) {
+                     words[0].classList.add('visible');
+                }
             }
 
             cardGlow1.style.backgroundColor = getComputedColor(currentAggregate.colors[0]);
@@ -4558,6 +4650,32 @@
             const drawFullChart = (progress = 1) => {
                 clear(ctx);
                 generateGrid();
+
+                if (aggregatedData.moes && aggregatedData.moes.length > 0) {
+                    for (let lineIdx = 0; lineIdx < 2; lineIdx++) {
+                        const upper = [], lower = [];
+                        aggregatedData.timestamps.forEach((date, i) => {
+                            const val = aggregatedData.values[lineIdx][i];
+                            const moe = aggregatedData.moes[i];
+                            if (val !== null && moe !== null) {
+                                const x = xScale(date);
+                                upper.push([x, yScale(val + moe)]);
+                                lower.unshift([x, yScale(val - moe)]);
+                            }
+                        });
+                        if (upper.length > 0) {
+                            const path = new Path2D();
+                            path.moveTo(upper[0][0], upper[0][1]);
+                            for (let j = 1; j < upper.length; j++) path.lineTo(upper[j][0], upper[j][1]);
+                            for (let j = 0; j < lower.length; j++) path.lineTo(lower[j][0], lower[j][1]);
+                            path.closePath();
+                            ctx.save();
+                            ctx.fillStyle = convertToRgba(getComputedColor(currentAggregate.colors[lineIdx]), 0.15);
+                            ctx.fill(path);
+                            ctx.restore();
+                        }
+                    }
+                }
 
                 linePaths.forEach((lineData, lineIdx) => {
                     if (!lineData) return;


### PR DESCRIPTION
## Summary
- integrate 2028 Newsom vs. Vance polls into main aggregate list with new color scheme
- account for pollster weights and recency when computing averages and MOE
- render confidence bands around Vance and Newsom trend lines
- color Vance's name red and stagger Newsom/Vance pop-in title animation

## Testing
- `node --check js/script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bd3f6a9483229ff8ae4f71ed9205