### PR TITLE
Add 2028 Newsom–Vance polling aggregate and chart

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -42,8 +42,12 @@
             --unfavorable-color-glow: rgba(249, 115, 22, 0.4);
             --trump-color: #ef4444;
             --harris-color: #3b82f6;
+            --vance-color: #dc2626;
+            --newsom-color: #2563eb;
             --trump-color-glow: rgba(239, 68, 68, 0.4);
             --harris-color-glow: rgba(59, 130, 246, 0.4);
+            --vance-color-glow: rgba(220, 38, 38, 0.4);
+            --newsom-color-glow: rgba(37, 99, 235, 0.4);
             --highlight-zoom-border: #8b5cf6;
             --highlight-zoom-bg: rgba(139, 92, 246, 0.15);
             --glass-bg: rgba(255, 255, 255, 0.02);
@@ -81,8 +85,12 @@
             --unfavorable-color-glow: rgba(249, 115, 22, 0.4);
             --trump-color: #ef4444;
             --harris-color: #3b82f6;
+            --vance-color: #dc2626;
+            --newsom-color: #2563eb;
             --trump-color-glow: rgba(239, 68, 68, 0.4);
             --harris-color-glow: rgba(59, 130, 246, 0.4);
+            --vance-color-glow: rgba(220, 38, 38, 0.4);
+            --newsom-color-glow: rgba(37, 99, 235, 0.4);
             --highlight-zoom-border: #8b5cf6;
             --highlight-zoom-bg: rgba(139, 92, 246, 0.15);
             --glass-bg: rgba(255, 255, 255, 0.05);
@@ -121,8 +129,12 @@
             --unfavorable-color-glow: rgba(245, 158, 11, 0.3);
             --trump-color: #dc2626;
             --harris-color: #2563eb;
+            --vance-color: #b91c1c;
+            --newsom-color: #1e3a8a;
             --trump-color-glow: rgba(220, 38, 38, 0.3);
             --harris-color-glow: rgba(37, 99, 235, 0.3);
+            --vance-color-glow: rgba(185, 28, 28, 0.3);
+            --newsom-color-glow: rgba(30, 58, 138, 0.3);
             --highlight-zoom-border: #7c3aed;
             --highlight-zoom-bg: rgba(124, 58, 237, 0.1);
             --glass-bg: rgba(0, 0, 0, 0.01);
@@ -273,6 +285,18 @@
             height: 1.1em;
         }
 
+        #poll-title .word-cycler.inline-flex {
+            display: inline-flex;
+            align-items: baseline;
+            width: auto;
+            height: auto;
+        }
+
+        #poll-title .word-cycler.inline-flex .vs {
+            margin: 0 4px;
+            font-weight: 700;
+        }
+
 
       
 
@@ -301,6 +325,12 @@
             opacity: 1;
             transform: translateY(0);
         }
+
+        /* Inline variant for titles that show multiple words simultaneously */
+        .animate-word.inline {
+            position: static;
+            width: auto;
+        }
         
         .animate-word.approve { color: var(--approve-color); }
         .animate-word.disapprove { color: var(--disapprove-color); }
@@ -310,6 +340,8 @@
         .animate-word.republican { color: var(--trump-color); }
         .animate-word.harris { color: var(--harris-color); }
         .animate-word.democrat { color: var(--harris-color); }
+        .animate-word.vance { color: var(--vance-color); }
+        .animate-word.newsom { color: var(--newsom-color); }
 
         .selectors-wrapper { 
             display: flex; 
@@ -2150,6 +2182,8 @@
         .poll-percentage.harris { color: var(--harris-color); }
         .poll-percentage.republican { color: var(--trump-color); }
         .poll-percentage.democrat { color: var(--harris-color); }
+        .poll-percentage.vance { color: var(--vance-color); }
+        .poll-percentage.newsom { color: var(--newsom-color); }
         
         .poll-date { 
             color: var(--text-secondary);
@@ -2414,6 +2448,8 @@
         .unfavorable-line { filter: drop-shadow(0 0 4px var(--unfavorable-color-glow)); }
         .trump-line { filter: drop-shadow(0 0 4px var(--trump-color-glow)); }
         .harris-line { filter: drop-shadow(0 0 4px var(--harris-color-glow)); }
+        .vance-line { filter: drop-shadow(0 0 4px var(--vance-color-glow)); }
+        .newsom-line { filter: drop-shadow(0 0 4px var(--newsom-color-glow)); }
         
         .mini-aggregate-display::after { 
             content: ''; 


### PR DESCRIPTION
## Summary
- integrate 2028 Newsom vs. Vance polls into main aggregate list with new color scheme
- account for pollster weights and recency when computing averages and MOE
- render confidence bands around Vance and Newsom trend lines
- color Vance's name red and stagger Newsom/Vance pop-in title animation
- clean up highlight zoom overlays and keep candidate names aligned side by side

## Testing
- `node --check js/script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bd3f6a9483229ff8ae4f71ed9205