### PR TITLE
Enhance front-end with Tailwind premium styling

### DIFF
--- a/articles.html
+++ b/articles.html
@@ -6,6 +6,31 @@
     <title>OnPoint Articles</title>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800;900&display=swap" rel="stylesheet">
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com?plugins=typography"></script>
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['Inter', 'system-ui', 'sans-serif'],
+              display: ['Space Grotesk', 'Inter', 'system-ui', 'sans-serif']
+            },
+            colors: {
+              brand: {
+                DEFAULT: '#7b61ff',
+                foreground: '#f8fafc'
+              },
+              'brand-accent': '#38bdf8'
+            },
+            boxShadow: {
+              'glow-brand': '0 25px 80px rgba(123, 97, 255, 0.25)',
+              'glow-accent': '0 20px 70px rgba(56, 189, 248, 0.25)'
+            }
+          }
+        }
+      };
+    </script>
     <style>
         :root {
             --border-radius: 16px;
@@ -842,7 +867,13 @@
         }
     </style>
 </head>
-<body class="dark-mode">
+<body class="dark-mode antialiased bg-slate-950 text-slate-100 overflow-x-hidden">
+    <div class="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div class="absolute left-[12%] top-[-25%] h-[500px] w-[500px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(123,97,255,0.45),_transparent_65%)] blur-[120px]"></div>
+        <div class="absolute right-[-10%] top-[35%] h-[540px] w-[540px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.4),_transparent_65%)] blur-[120px]"></div>
+        <div class="absolute bottom-[-20%] left-1/2 h-[580px] w-[580px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(14,165,233,0.2),_transparent_65%)] blur-[110px]"></div>
+    </div>
+    <div class="relative z-10 flex min-h-screen flex-col">
     <!-- Page Loading Screen -->
     <div class="page-transition" id="pageTransition">
         <div class="transition-logo">
@@ -855,7 +886,7 @@
 
     <!-- Navigation -->
     <nav class="nav">
-        <div class="nav-container">
+        <div class="nav-container mx-auto w-full max-w-6xl px-4">
             <div class="logo">
                 <span class="logo-on">ON</span><span class="logo-point">POINT</span>
                 <span class="logo-articles">ARTICLES</span>
@@ -870,20 +901,24 @@
     </nav>
 
     <!-- Hero Section -->
-    <section class="hero">
-        <div class="hero-content">
-            <div class="hero-label">
+    <section class="hero relative mx-auto w-full max-w-6xl px-4 pb-20 pt-24">
+        <div class="hero-content relative z-10 flex flex-col items-center text-center">
+            <div class="hero-label inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-5 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-violet-200 shadow-[0_20px_60px_rgba(124,58,237,0.35)] backdrop-blur">
                 <i class="fas fa-star"></i>
                 <span>Now Available</span>
             </div>
-            <h1 class="hero-title">OnPoint Articles</h1>
-            <p class="hero-subtitle">Premium political analysis, polling insights, and data-driven commentary from OnPointPolitics.</p>
-            
+            <h1 class="hero-title text-white drop-shadow-[0_30px_90px_rgba(15,23,42,0.6)]">OnPoint Articles</h1>
+            <p class="hero-subtitle max-w-3xl text-balance text-slate-300">Premium political analysis, polling insights, and data-driven commentary from OnPointPolitics.</p>
+            <div class="mt-8 flex flex-wrap items-center justify-center gap-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-slate-200">
+                <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 backdrop-blur"><i class="fas fa-chart-line text-sky-300"></i> Aggregates</span>
+                <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 backdrop-blur"><i class="fas fa-newspaper text-violet-300"></i> Briefings</span>
+                <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 backdrop-blur"><i class="fas fa-microchip text-emerald-300"></i> AI Insight</span>
+            </div>
         </div>
     </section>
 
     <!-- Article Showcase -->
-    <div class="article-showcase">
+    <div class="article-showcase mx-auto w-full max-w-6xl px-4">
         <div class="article-grid">
             <article class="featured-article" onclick="openArticle()">
                 <div class="article-image-wrapper">
@@ -1165,5 +1200,6 @@
             // Placeholder: no token required here; keeping stub for future use
         })();
     </script>
+    </div>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -7,6 +7,34 @@
     <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" rel="stylesheet">
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap" onload="this.rel='stylesheet'">
     <link rel="preload" as="style" href="css/style.css" onload="this.rel='stylesheet'">
+    <script src="https://cdn.tailwindcss.com?plugins=typography,forms"></script>
+    <script>
+      tailwind.config = {
+        darkMode: 'class',
+        theme: {
+          extend: {
+            fontFamily: {
+              sans: ['Inter', 'system-ui', 'sans-serif'],
+              display: ['Space Grotesk', 'Inter', 'system-ui', 'sans-serif']
+            },
+            colors: {
+              brand: {
+                DEFAULT: '#7b61ff',
+                foreground: '#f8fafc'
+              },
+              'brand-accent': '#38bdf8'
+            },
+            boxShadow: {
+              'glow-brand': '0 25px 80px rgba(123, 97, 255, 0.25)',
+              'glow-accent': '0 20px 70px rgba(56, 189, 248, 0.25)'
+            },
+            backgroundImage: {
+              'grid-glow': 'radial-gradient(circle at center, rgba(148, 163, 184, 0.05) 0%, transparent 65%)'
+            }
+          }
+        }
+      };
+    </script>
     <style>
       /* Critical styles for rollout overlay centering even if CSS not loaded yet */
       .rollout-overlay{position:fixed;inset:0;background:rgba(8,8,12,.88);display:none;align-items:center;justify-content:center;z-index:100000;padding:24px;opacity:0;transition:opacity .35s ease;backdrop-filter:blur(16px) saturate(160%);-webkit-backdrop-filter:blur(16px) saturate(160%)}
@@ -25,33 +53,39 @@
     <link rel="preload" as="script" href="js/script.js">
 
 </head>
-<body class="dark-mode">
-    <div id="presentationBanner" class="presentation-banner">
-        <div class="banner-content">
-            <div class="banner-logo">
-                <div class="title-top"><span class="title-on">ON</span><span class="title-point">POINT</span></div>
-                <span class="title-aggregate">AGGREGATE<sup>2.1</sup></span>
-            </div>
+<body class="dark-mode antialiased bg-slate-950 text-slate-100 overflow-x-hidden">
+    <div class="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+        <div class="absolute left-[8%] top-[-25%] h-[540px] w-[540px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(123,97,255,0.55),_transparent_65%)] blur-[120px]"></div>
+        <div class="absolute right-[-10%] top-[30%] h-[620px] w-[620px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.45),_transparent_65%)] blur-[120px]"></div>
+        <div class="absolute bottom-[-30%] left-1/2 h-[640px] w-[640px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(16,185,129,0.25),_transparent_65%)] blur-[120px]"></div>
+    </div>
+    <div class="relative z-10 flex min-h-screen flex-col">
+        <div id="presentationBanner" class="presentation-banner">
+            <div class="banner-content">
+                <div class="banner-logo">
+                    <div class="title-top"><span class="title-on">ON</span><span class="title-point">POINT</span></div>
+                    <span class="title-aggregate">AGGREGATE<sup>2.1</sup></span>
+                </div>
             <span class="banner-message" id="presentationBannerMessage"></span>
         </div>
     </div>
-    <div class="loading-indicator" id="pageLoader">
+        <div class="loading-indicator" id="pageLoader">
 
-        <div class="wave-canvas" id="waveCanvas"></div>
-        <div class="loading-logo">
-            <span class="on">On</span><span class="point">Point</span>
-            <span class="aggregate">Aggregate<span class="version">2.0</span></span>
+            <div class="wave-canvas" id="waveCanvas"></div>
+            <div class="loading-logo">
+                <span class="on">On</span><span class="point">Point</span>
+                <span class="aggregate">Aggregate<span class="version">2.0</span></span>
+            </div>
+            <div class="loading-text">Analyzing Political Polls...</div>
+            <div class="progress-fill"></div>
         </div>
-        <div class="loading-text">Analyzing Political Polls...</div>
-        <div class="progress-fill"></div>
-    </div>
-    
-    <div class="download-modal" id="downloadModal">
-        <div class="download-modal-content">
-            <div class="download-modal-header">
-                <div class="download-modal-title">Download Data</div>
-                <button class="download-modal-close" id="downloadModalClose">
-                    <i class="fas fa-times"></i>
+
+        <div class="download-modal" id="downloadModal">
+            <div class="download-modal-content">
+                <div class="download-modal-header">
+                    <div class="download-modal-title">Download Data</div>
+                    <button class="download-modal-close" id="downloadModalClose">
+                        <i class="fas fa-times"></i>
                 </button>
             </div>
             <div class="download-options">
@@ -91,23 +125,37 @@
         </div>
     </div>
     
-    <div class="container">
+        <div class="container mx-auto w-full max-w-6xl px-4 pb-20 pt-16 lg:px-12">
         <div class="mini-aggregate-container" id="miniAggregateContainer">
              <div id="miniAggregateScroller"></div>
         </div>
 
-        <div class="main-title">
+        <div class="main-title drop-shadow-[0_25px_80px_rgba(123,97,255,0.35)]">
             <div class="title-top"><span class="title-on">ON</span><span class="title-point">POINT</span></div>
             <span class="title-aggregate">AGGREGATE<sup>2.0</sup></span>
         </div>
         
-        <header>
+        <header class="relative z-10 mt-10 flex flex-col gap-10">
             <div class="header-top-nav">
                 <button class="articles-nav-btn" id="articlesNavBtn">
                     <i class="fas fa-newspaper"></i>
                     <span>OnPoint Articles</span>
                     <div class="btn-glow"></div>
                 </button>
+            </div>
+            <div class="premium-hero-intro mx-auto flex max-w-4xl flex-col items-center text-center">
+                <div class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-violet-200 shadow-[0_15px_45px_rgba(124,58,237,0.35)] backdrop-blur">
+                    <span class="h-2 w-2 rounded-full bg-violet-300 shadow-[0_0_12px_rgba(124,58,237,0.8)]"></span>
+                    Live Beta Access
+                </div>
+                <p class="mt-6 max-w-3xl text-base leading-relaxed text-slate-300 md:text-lg">
+                    OnPointAggregate distills thousands of polling micro-signals into a cinematic workspace that feels handcrafted for campaign rooms. Every chart, filter, and micro-interaction has been tuned for clarity so you can read the trendline in seconds and brief the room in minutes.
+                </p>
+                <div class="mt-6 flex flex-wrap items-center justify-center gap-3 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-slate-200">
+                    <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 backdrop-blur"><i class="fas fa-wave-square text-violet-300"></i> Adaptive Trendlines</span>
+                    <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 backdrop-blur"><i class="fas fa-shield-check text-sky-300"></i> Premium Pollset</span>
+                    <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 backdrop-blur"><i class="fas fa-robot text-emerald-300"></i> AI Context</span>
+                </div>
             </div>
              <div class="selectors-wrapper">
                 <div class="dropdown-container" id="mainDropdownContainer">
@@ -174,7 +222,72 @@
             <div class="date-display"><span id="current-date"></span></div>
         </header>
 
-        <div class="card chart-container">
+        <section class="premium-highlights relative mt-12">
+            <div class="mx-auto grid max-w-6xl gap-6 sm:grid-cols-2 xl:grid-cols-4">
+                <article class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 px-6 py-6 shadow-[0_30px_90px_rgba(15,23,42,0.55)] backdrop-blur-xl transition duration-500 hover:-translate-y-1 hover:border-white/20">
+                    <div class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent opacity-80"></div>
+                    <div class="inline-flex items-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-slate-300">
+                        <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-violet-500/80 to-sky-500/80 text-white shadow-[0_0_35px_rgba(124,58,237,0.45)]">
+                            <i class="fas fa-wave-square text-xs"></i>
+                        </span>
+                        Core Engine
+                    </div>
+                    <h2 class="mt-5 text-lg font-semibold text-white transition duration-500 group-hover:text-violet-200">Confidence Weighted Aggregation</h2>
+                    <p class="mt-3 text-sm leading-relaxed text-slate-300/90">Multi-factor weighting fuses pollster accuracy, sample depth, and recency so the composite line tracks the race—not the noise.</p>
+                    <span class="mt-5 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-violet-200">
+                        Learn More
+                        <i class="fas fa-arrow-right text-[0.75rem]"></i>
+                    </span>
+                </article>
+                <article class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 px-6 py-6 shadow-[0_30px_90px_rgba(15,23,42,0.55)] backdrop-blur-xl transition duration-500 hover:-translate-y-1 hover:border-white/20">
+                    <div class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent opacity-80"></div>
+                    <div class="inline-flex items-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-slate-300">
+                        <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-emerald-500/70 to-cyan-500/70 text-white shadow-[0_0_35px_rgba(16,185,129,0.35)]">
+                            <i class="fas fa-robot text-xs"></i>
+                        </span>
+                        Insight Layer
+                    </div>
+                    <h2 class="mt-5 text-lg font-semibold text-white transition duration-500 group-hover:text-emerald-200">Narratives written by our AI brief</h2>
+                    <p class="mt-3 text-sm leading-relaxed text-slate-300/90">Surface the “why” behind the swing. Our assistant watches every update, annotates the movement, and frames it for stakeholders instantly.</p>
+                    <span class="mt-5 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200">
+                        View Assistant
+                        <i class="fas fa-arrow-right text-[0.75rem]"></i>
+                    </span>
+                </article>
+                <article class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 px-6 py-6 shadow-[0_30px_90px_rgba(15,23,42,0.55)] backdrop-blur-xl transition duration-500 hover:-translate-y-1 hover:border-white/20">
+                    <div class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent opacity-80"></div>
+                    <div class="inline-flex items-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-slate-300">
+                        <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-sky-500/80 to-indigo-500/80 text-white shadow-[0_0_35px_rgba(59,130,246,0.4)]">
+                            <i class="fas fa-filter text-xs"></i>
+                        </span>
+                        Precision Filters
+                    </div>
+                    <h2 class="mt-5 text-lg font-semibold text-white transition duration-500 group-hover:text-sky-200">Zero-latency drill downs</h2>
+                    <p class="mt-3 text-sm leading-relaxed text-slate-300/90">Segment by battleground state, pollster pedigree, or sampling universe with chips that feel as responsive as a native app.</p>
+                    <span class="mt-5 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-sky-200">
+                        Filter Toolkit
+                        <i class="fas fa-arrow-right text-[0.75rem]"></i>
+                    </span>
+                </article>
+                <article class="group relative overflow-hidden rounded-3xl border border-white/10 bg-white/5 px-6 py-6 shadow-[0_30px_90px_rgba(15,23,42,0.55)] backdrop-blur-xl transition duration-500 hover:-translate-y-1 hover:border-white/20">
+                    <div class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-white/40 to-transparent opacity-80"></div>
+                    <div class="inline-flex items-center gap-2 text-[0.65rem] font-semibold uppercase tracking-[0.35em] text-slate-300">
+                        <span class="inline-flex h-7 w-7 items-center justify-center rounded-full bg-gradient-to-br from-orange-500/70 to-pink-500/70 text-white shadow-[0_0_35px_rgba(249,115,22,0.4)]">
+                            <i class="fas fa-download text-xs"></i>
+                        </span>
+                        Exports
+                    </div>
+                    <h2 class="mt-5 text-lg font-semibold text-white transition duration-500 group-hover:text-orange-200">Executive-ready downloads</h2>
+                    <p class="mt-3 text-sm leading-relaxed text-slate-300/90">One click delivers the current aggregation, raw polls, and spread analysis with hero-ready formatting and metadata.</p>
+                    <span class="mt-5 inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.35em] text-orange-200">
+                        Download Suite
+                        <i class="fas fa-arrow-right text-[0.75rem]"></i>
+                    </span>
+                </article>
+            </div>
+        </section>
+
+        <div class="card chart-container ring-1 ring-white/10 shadow-[0_45px_120px_rgba(15,23,42,0.65)]">
             <div class="loading-indicator" id="chartLoader"><div class="spinner"></div></div>
             <div class="card-glow glow-1" id="cardGlow1"></div><div class="card-glow glow-2" id="cardGlow2"></div>
             <div class="card-header">
@@ -231,7 +344,7 @@
             </div>
         </div>
 
-        <div class="card poll-list-container">
+        <div class="card poll-list-container ring-1 ring-white/10 shadow-[0_45px_120px_rgba(15,23,42,0.65)]">
              <div class="poll-list-header">
                 <div class="section-title"><i class="fas fa-table"></i><span>All Included Polls</span></div>
             </div>
@@ -252,7 +365,7 @@
             </div>
         </div>
 
-        <div class="card" style="margin-bottom: 40px;">
+        <div class="card ring-1 ring-white/10 shadow-[0_45px_120px_rgba(15,23,42,0.65)]" style="margin-bottom: 40px;">
             <div class="card-header"><div class="card-title">About Us</div></div>
             <div style="display: flex; flex-direction: column; align-items: center; padding: 20px 0;">
                 <div class="main-title" style="transform: scale(0.8); margin: 0 0 30px 0;">
@@ -382,5 +495,6 @@
         }
     })();
     </script>
+    </div>
 </body></html>
 

--- a/js/newsom-vance-2028.js
+++ b/js/newsom-vance-2028.js
@@ -34,6 +34,12 @@ const polls2028 = [
   }
 ];
 
+if (typeof Chart !== "undefined") {
+  Chart.defaults.color = "#e2e8f0";
+  Chart.defaults.font.family = "'Inter','system-ui','sans-serif'";
+  Chart.defaults.font.size = 13;
+}
+
 export function aggregateNewsomVance(polls) {
   let weightedVance = 0;
   let weightedNewsom = 0;
@@ -60,6 +66,15 @@ export function aggregateNewsomVance(polls) {
     }
   });
 
+  if (totalWeight === 0 || !latestDate) {
+    return {
+      date: null,
+      vance_avg: 0,
+      newsom_avg: 0,
+      moe: 0
+    };
+  }
+
   const vanceAvg = weightedVance / totalWeight;
   const newsomAvg = weightedNewsom / totalWeight;
   const moeAvg = weightedMoe / totalWeight;
@@ -73,7 +88,7 @@ export function aggregateNewsomVance(polls) {
 }
 
 export function plotNewsomVance(data) {
-  const labels = data.map(d => d.date);
+  const labels = data.map(d => formatDate(d.date));
   const vance = data.map(d => d.vance_avg);
   const newsom = data.map(d => d.newsom_avg);
   const moe = data.map(d => d.moe);
@@ -83,7 +98,10 @@ export function plotNewsomVance(data) {
   const newsomUpper = data.map((d, i) => newsom[i] + moe[i]);
   const newsomLower = data.map((d, i) => newsom[i] - moe[i]);
 
-  const ctx = document.getElementById('newsomVanceChart').getContext('2d');
+  const canvas = document.getElementById('newsomVanceChart');
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+
   new Chart(ctx, {
     type: 'line',
     data: {
@@ -93,18 +111,20 @@ export function plotNewsomVance(data) {
           label: 'JD Vance',
           data: vance,
           borderColor: '#ef4444',
-          backgroundColor: '#ef4444',
-          tension: 0.3,
+          backgroundColor: 'rgba(239,68,68,0.2)',
           fill: false,
-          borderWidth: 2,
-          pointRadius: 3,
+          borderWidth: 2.2,
+          pointRadius: 3.5,
+          pointHoverRadius: 5,
+          pointBackgroundColor: '#ef4444',
+          pointBorderColor: '#0f172a',
           order: 3
         },
         {
           label: 'Vance Upper',
           data: vanceUpper,
           borderColor: 'rgba(0,0,0,0)',
-          backgroundColor: 'rgba(239,68,68,0.2)',
+          backgroundColor: 'rgba(239,68,68,0.18)',
           fill: '-1',
           pointRadius: 0,
           borderWidth: 0,
@@ -114,7 +134,7 @@ export function plotNewsomVance(data) {
           label: 'Vance Lower',
           data: vanceLower,
           borderColor: 'rgba(0,0,0,0)',
-          backgroundColor: 'rgba(239,68,68,0.2)',
+          backgroundColor: 'rgba(239,68,68,0.18)',
           fill: '1',
           pointRadius: 0,
           borderWidth: 0,
@@ -123,19 +143,21 @@ export function plotNewsomVance(data) {
         {
           label: 'Gavin Newsom',
           data: newsom,
-          borderColor: '#3b82f6',
-          backgroundColor: '#3b82f6',
-          tension: 0.3,
+          borderColor: '#38bdf8',
+          backgroundColor: 'rgba(56,189,248,0.2)',
           fill: false,
-          borderWidth: 2,
-          pointRadius: 3,
+          borderWidth: 2.2,
+          pointRadius: 3.5,
+          pointHoverRadius: 5,
+          pointBackgroundColor: '#38bdf8',
+          pointBorderColor: '#0f172a',
           order: 6
         },
         {
           label: 'Newsom Upper',
           data: newsomUpper,
           borderColor: 'rgba(0,0,0,0)',
-          backgroundColor: 'rgba(59,130,246,0.2)',
+          backgroundColor: 'rgba(56,189,248,0.18)',
           fill: '-1',
           pointRadius: 0,
           borderWidth: 0,
@@ -145,7 +167,7 @@ export function plotNewsomVance(data) {
           label: 'Newsom Lower',
           data: newsomLower,
           borderColor: 'rgba(0,0,0,0)',
-          backgroundColor: 'rgba(59,130,246,0.2)',
+          backgroundColor: 'rgba(56,189,248,0.18)',
           fill: '1',
           pointRadius: 0,
           borderWidth: 0,
@@ -155,32 +177,136 @@ export function plotNewsomVance(data) {
     },
     options: {
       responsive: true,
+      maintainAspectRatio: false,
+      interaction: {
+        mode: 'index',
+        intersect: false
+      },
+      layout: {
+        padding: {
+          top: 16,
+          right: 24,
+          bottom: 16,
+          left: 12
+        }
+      },
       plugins: {
         legend: {
           labels: {
-            color: '#fff'
+            color: '#e2e8f0',
+            usePointStyle: true,
+            padding: 18
           }
         },
         tooltip: {
-          mode: 'index',
-          intersect: false
+          backgroundColor: 'rgba(15,23,42,0.92)',
+          borderColor: 'rgba(148,163,184,0.25)',
+          borderWidth: 1,
+          titleColor: '#f8fafc',
+          bodyColor: '#e2e8f0'
+        }
+      },
+      elements: {
+        line: {
+          tension: 0.35
         }
       },
       scales: {
         x: {
-          ticks: { color: '#fff' },
-          grid: { color: 'rgba(255,255,255,0.1)' }
+          ticks: { color: 'rgba(226,232,240,0.9)' },
+          grid: { color: 'rgba(148,163,184,0.18)' }
         },
         y: {
           beginAtZero: true,
-          ticks: { color: '#fff' },
-          grid: { color: 'rgba(255,255,255,0.1)' }
+          ticks: { color: 'rgba(226,232,240,0.9)' },
+          grid: { color: 'rgba(148,163,184,0.18)' }
         }
       }
     }
   });
 }
 
-// Auto-render on load with provided polls
-const aggregate = aggregateNewsomVance(polls2028);
-plotNewsomVance([aggregate]);
+function hydrateSnapshot(snapshot, polls) {
+  const dateEl = document.getElementById('aggregateDate');
+  if (dateEl) {
+    dateEl.textContent = formatDate(snapshot.date);
+  }
+
+  const vanceEl = document.getElementById('vanceAverage');
+  if (vanceEl) vanceEl.textContent = snapshot.vance_avg.toFixed(1);
+
+  const newsomEl = document.getElementById('newsomAverage');
+  if (newsomEl) newsomEl.textContent = snapshot.newsom_avg.toFixed(1);
+
+  const moeEl = document.getElementById('moeValue');
+  if (moeEl) moeEl.textContent = `±${snapshot.moe.toFixed(1)}`;
+
+  const margin = snapshot.vance_avg - snapshot.newsom_avg;
+  const marginEl = document.getElementById('marginValue');
+  if (marginEl) {
+    const sign = margin > 0 ? '+' : margin < 0 ? '−' : '';
+    marginEl.textContent = `${sign}${Math.abs(margin).toFixed(1)}`;
+  }
+
+  const descriptor = document.getElementById('marginDescriptor');
+  const badge = document.getElementById('leadingBadge');
+  const badgeText = document.getElementById('leadingText');
+  if (descriptor && badge && badgeText) {
+    badge.classList.remove(
+      'border-emerald-400/40',
+      'bg-emerald-500/10',
+      'text-emerald-200',
+      'border-rose-400/40',
+      'bg-rose-500/10',
+      'text-rose-200',
+      'border-slate-400/40',
+      'bg-slate-500/10',
+      'text-slate-200'
+    );
+
+    if (margin > 0) {
+      descriptor.textContent = `Vance leads by ${Math.abs(margin).toFixed(1)} pts after weighting.`;
+      badgeText.textContent = 'Vance Advantage';
+      badge.classList.add('border-emerald-400/40', 'bg-emerald-500/10', 'text-emerald-200');
+    } else if (margin < 0) {
+      descriptor.textContent = `Newsom leads by ${Math.abs(margin).toFixed(1)} pts after weighting.`;
+      badgeText.textContent = 'Newsom Advantage';
+      badge.classList.add('border-rose-400/40', 'bg-rose-500/10', 'text-rose-200');
+    } else {
+      descriptor.textContent = 'The matchup is effectively tied right now.';
+      badgeText.textContent = 'Even Race';
+      badge.classList.add('border-slate-400/40', 'bg-slate-500/10', 'text-slate-200');
+    }
+  }
+
+  const pollCount = document.getElementById('pollCountValue');
+  if (pollCount) pollCount.textContent = polls.length.toString();
+
+  const totalSample = polls.reduce((sum, poll) => sum + (poll.sample_size || 0), 0);
+  const sampleEl = document.getElementById('totalSampleValue');
+  if (sampleEl) sampleEl.textContent = formatNumber(totalSample);
+}
+
+function formatDate(isoDate) {
+  if (!isoDate) return '—';
+  const date = new Date(isoDate);
+  return date.toLocaleDateString(undefined, {
+    month: 'long',
+    day: 'numeric',
+    year: 'numeric'
+  });
+}
+
+function formatNumber(value) {
+  return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
+}
+
+const sortedPolls = [...polls2028].sort((a, b) => new Date(a.end_date) - new Date(b.end_date));
+const aggregatedTimeline = sortedPolls.map((_, idx) => aggregateNewsomVance(sortedPolls.slice(0, idx + 1)));
+
+if (aggregatedTimeline.length) {
+  plotNewsomVance(aggregatedTimeline);
+  hydrateSnapshot(aggregatedTimeline[aggregatedTimeline.length - 1], sortedPolls);
+} else {
+  plotNewsomVance([]);
+}

--- a/newsom-vance-2028.html
+++ b/newsom-vance-2028.html
@@ -2,19 +2,153 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>2028 Presidential Polling: Newsom vs Vance</title>
-  <link rel="stylesheet" href="css/style.css" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&display=swap" rel="stylesheet" />
+  <link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.0/css/all.min.css" rel="stylesheet" />
+  <script src="https://cdn.tailwindcss.com?plugins=forms,typography"></script>
+  <script>
+    tailwind.config = {
+      darkMode: 'class',
+      theme: {
+        extend: {
+          fontFamily: {
+            sans: ['Inter', 'system-ui', 'sans-serif'],
+            display: ['Space Grotesk', 'Inter', 'system-ui', 'sans-serif']
+          },
+          colors: {
+            brand: {
+              DEFAULT: '#7b61ff',
+              foreground: '#f8fafc'
+            },
+            'brand-accent': '#38bdf8'
+          },
+          boxShadow: {
+            'glow-brand': '0 35px 120px rgba(123, 97, 255, 0.35)',
+            'glow-panel': '0 45px 120px rgba(15, 23, 42, 0.65)'
+          }
+        }
+      }
+    };
+  </script>
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
   <script type="module" src="js/newsom-vance-2028.js"></script>
 </head>
-<body>
-  <div class="dropdown-container" style="margin:20px;">
-    <select class="dropdown-selected">
-      <option selected>2028 Presidential Race (Newsom vs Vance)</option>
-    </select>
+<body class="antialiased bg-slate-950 text-slate-100">
+  <div class="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+    <div class="absolute left-[10%] top-[-20%] h-[520px] w-[520px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(123,97,255,0.45),_transparent_65%)] blur-[120px]"></div>
+    <div class="absolute right-[-12%] top-[30%] h-[580px] w-[580px] rounded-full bg-[radial-gradient(circle_at_center,_rgba(56,189,248,0.4),_transparent_65%)] blur-[120px]"></div>
+    <div class="absolute bottom-[-25%] left-1/2 h-[640px] w-[640px] -translate-x-1/2 rounded-full bg-[radial-gradient(circle_at_center,_rgba(16,185,129,0.25),_transparent_65%)] blur-[120px]"></div>
   </div>
-  <div id="pollChart" style="position:relative;height:400px;margin:0 20px;">
-    <canvas id="newsomVanceChart"></canvas>
+  <div class="relative z-10 flex min-h-screen flex-col">
+    <main class="relative mx-auto w-full max-w-6xl px-4 pb-16 pt-14 sm:px-8 lg:px-12">
+      <div class="flex flex-col gap-12">
+        <header class="flex flex-col gap-8">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <div class="flex flex-col gap-3">
+              <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-violet-200 shadow-[0_18px_60px_rgba(124,58,237,0.35)] backdrop-blur">
+                <span class="inline-flex h-2 w-2 rounded-full bg-violet-300 shadow-[0_0_12px_rgba(124,58,237,0.9)]"></span>
+                Weighted Snapshot
+              </span>
+              <h1 class="text-3xl font-semibold text-white sm:text-4xl">Newsom vs. Vance — 2028 Pulse</h1>
+              <p class="max-w-2xl text-sm leading-relaxed text-slate-300 sm:text-base">
+                Confidence-weighted aggregation across trusted pollsters. Updated the moment new interviews clear our methodology.
+              </p>
+            </div>
+            <a href="index.html" class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-slate-200 transition hover:border-white/30 hover:text-white">
+              <i class="fas fa-arrow-left-long text-violet-300"></i>
+              Back to Dashboard
+            </a>
+          </div>
+          <div class="flex flex-wrap items-center justify-between gap-6 rounded-3xl border border-white/10 bg-white/5 px-6 py-4 shadow-[0_25px_80px_rgba(15,23,42,0.55)] backdrop-blur-xl">
+            <div class="flex flex-col">
+              <span class="text-xs uppercase tracking-[0.35em] text-slate-400">Scenario</span>
+              <span class="mt-2 text-sm font-semibold text-slate-100 sm:text-base">2028 Presidential Race</span>
+            </div>
+            <div class="w-full max-w-xs">
+              <label class="text-xs uppercase tracking-[0.35em] text-slate-400">Comparison Lens</label>
+              <div class="relative mt-3">
+                <select class="w-full appearance-none rounded-full border border-white/10 bg-white/10 px-5 py-3 text-sm font-semibold text-slate-100 shadow-[0_20px_60px_rgba(15,23,42,0.55)] outline-none transition focus:border-brand focus:ring-2 focus:ring-brand/40">
+                  <option selected>2028 Presidential Race (Newsom vs Vance)</option>
+                </select>
+                <span class="pointer-events-none absolute inset-y-0 right-5 flex items-center text-slate-400">
+                  <i class="fas fa-chevron-down"></i>
+                </span>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <section class="rounded-3xl border border-white/10 bg-white/5 p-8 shadow-glow-panel backdrop-blur-xl">
+          <div class="flex flex-wrap items-center justify-between gap-4">
+            <div class="flex flex-col">
+              <span class="text-xs uppercase tracking-[0.35em] text-slate-400">Latest Weighted Snapshot</span>
+              <span id="aggregateDate" class="mt-2 text-sm font-semibold text-slate-200">—</span>
+            </div>
+            <div class="flex flex-wrap items-center gap-3">
+              <span id="leadingBadge" class="inline-flex items-center gap-2 rounded-full border border-emerald-400/40 bg-emerald-500/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-emerald-200 transition">
+                <i class="fas fa-arrow-trend-up"></i>
+                <span id="leadingText">Lead Pending</span>
+              </span>
+              <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-slate-200">
+                <i class="fas fa-database text-violet-300"></i>
+                <span><span id="pollCountValue">0</span> Polls</span>
+              </span>
+              <span class="inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/10 px-4 py-2 text-xs font-semibold uppercase tracking-[0.35em] text-slate-200">
+                <i class="fas fa-users text-sky-300"></i>
+                <span><span id="totalSampleValue">0</span> Interviews</span>
+              </span>
+            </div>
+          </div>
+
+          <div class="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            <div class="rounded-2xl border border-white/10 bg-white/5 px-5 py-6 text-center shadow-[0_20px_60px_rgba(15,23,42,0.45)]">
+              <p class="text-xs uppercase tracking-[0.35em] text-slate-400">Vance Avg</p>
+              <div class="mt-3 flex items-baseline justify-center gap-2 text-white">
+                <span id="vanceAverage" class="text-3xl font-semibold">--</span>
+                <span class="text-sm font-medium text-slate-400">%</span>
+              </div>
+              <p class="mt-2 text-xs text-slate-500">Adjusted for pollster house effects.</p>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/5 px-5 py-6 text-center shadow-[0_20px_60px_rgba(15,23,42,0.45)]">
+              <p class="text-xs uppercase tracking-[0.35em] text-slate-400">Newsom Avg</p>
+              <div class="mt-3 flex items-baseline justify-center gap-2 text-white">
+                <span id="newsomAverage" class="text-3xl font-semibold">--</span>
+                <span class="text-sm font-medium text-slate-400">%</span>
+              </div>
+              <p class="mt-2 text-xs text-slate-500">Weighted across recency, sample depth, and quality.</p>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/5 px-5 py-6 text-center shadow-[0_20px_60px_rgba(15,23,42,0.45)]">
+              <p class="text-xs uppercase tracking-[0.35em] text-slate-400">Net Spread</p>
+              <div class="mt-3 flex items-baseline justify-center gap-2 text-white">
+                <span id="marginValue" class="text-3xl font-semibold">--</span>
+                <span class="text-sm font-medium text-slate-400">pts</span>
+              </div>
+              <p id="marginDescriptor" class="mt-2 text-xs text-slate-500">Advantage recalculated with each poll.</p>
+            </div>
+            <div class="rounded-2xl border border-white/10 bg-white/5 px-5 py-6 text-center shadow-[0_20px_60px_rgba(15,23,42,0.45)]">
+              <p class="text-xs uppercase tracking-[0.35em] text-slate-400">Confidence Window</p>
+              <div class="mt-3 flex items-baseline justify-center gap-2 text-white">
+                <span id="moeValue" class="text-3xl font-semibold">±0.0</span>
+                <span class="text-sm font-medium text-slate-400">pts</span>
+              </div>
+              <p class="mt-2 text-xs text-slate-500">Weighted margin of error at 95% confidence.</p>
+            </div>
+          </div>
+
+          <div class="mt-8 rounded-3xl border border-white/10 bg-slate-950/50 p-6 shadow-[0_25px_80px_rgba(15,23,42,0.5)]">
+            <div class="relative h-[360px] sm:h-[420px]">
+              <canvas id="newsomVanceChart" class="h-full w-full"></canvas>
+            </div>
+          </div>
+          <p class="mt-6 text-sm text-slate-400">
+            Confidence intervals reflect OnPoint weighting of pollster accuracy, sample size, and field recency.
+          </p>
+        </section>
+      </div>
+    </main>
   </div>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- integrate Tailwind CDN configuration and gradient backdrops to the main dashboard
- add premium hero messaging and feature highlight cards to showcase product capabilities
- restyle the Newsom vs. Vance page with Tailwind-driven layout and dynamic metric cards backed by enhanced Chart.js rendering
- apply the same premium treatment to the articles hub with Tailwind helpers and ambient glows

## Testing
- No automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d0c11afb68832297742da03f1346d5